### PR TITLE
minipupper_ros #2: yocs_velocity_smoother quits with "bond broken exiting"

### DIFF
--- a/launch/velocity_smoother.launch
+++ b/launch/velocity_smoother.launch
@@ -12,7 +12,7 @@
   <arg name="odom_topic"            default="odom"/>
 
   <node pkg="nodelet" type="nodelet" name="$(arg node_name)"
-        args="load yocs_velocity_smoother/VelocitySmootherNodelet $(arg nodelet_manager_name)">
+        args="load yocs_velocity_smoother/VelocitySmootherNodelet $(arg nodelet_manager_name) --no-bond">
         
     <!-- parameters -->
     <rosparam file="$(arg config_file)" command="load"/>


### PR DESCRIPTION
disable bond checking to workaround [minipupper_ros #2: ](https://github.com/AlessioMorale/minipupper_ros/issues/2) yocs_velocity_smoother quits with "bond broken exiting"